### PR TITLE
Add dependencies documentation

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,3 +1,29 @@
 # Building
 
 Build instructions if Klipper Mod will only be provided after completing the pending [build system rework](https://github.com/xblax/flashforge_ad5m_klipper_mod/issues/32). In the meantime, if you are interested you look at the [Buildroot manual](https://buildroot.org/downloads/manual/manual.html).
+
+## Dependencies
+
+Before building the project, ensure you have the following dependencies installed on your system:
+
+- `build-essential`
+- `git`
+- `wget`
+- `python3`
+- `python3-pip`
+- `rsync`
+- `xz-utils`
+- `libncurses5-dev`
+- `libssl-dev`
+- `bc`
+- `flex`
+- `bison`
+- `libelf-dev`
+- `libudev-dev`
+- `libpci-dev`
+- `libiberty-dev`
+- `autoconf`
+- `automake`
+- `libtool`
+- `pkg-config`
+- `zlib1g-dev`


### PR DESCRIPTION
Add a section to `docs/BUILDING.md` describing the dependencies needed to install before building.

* List the required dependencies such as `build-essential`, `git`, `wget`, `python3`, `python3-pip`, `rsync`, `xz-utils`, `libncurses5-dev`, `libssl-dev`, `bc`, `flex`, `bison`, `libelf-dev`, `libudev-dev`, `libpci-dev`, `libiberty-dev`, `autoconf`, `automake`, `libtool`, `pkg-config`, and `zlib1g-dev`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Megasteel32/FlashforgeAD5M-BetterKlipper/pull/1?shareId=cd8b8a84-6941-4c5c-b577-220bf16fe260).